### PR TITLE
Fixed Subtraction

### DIFF
--- a/src/Numeric/Log.hs
+++ b/src/Numeric/Log.hs
@@ -188,6 +188,21 @@ negInf :: Fractional a => a
 negInf = -(1/0)
 {-# INLINE negInf #-}
 
+-- | Handle subtraction.
+--
+-- >>> 3 - 1 :: Log Double
+-- 2.0000000000000004
+--
+-- >>> 1 - 3 :: Log Double
+-- NaN
+-- 
+-- >>> 3 - 2 :: Log Float
+-- 1.0
+--
+-- >>> 1 - 3 :: Log Float
+-- NaN
+--
+
 instance (Precise a, RealFloat a) => Num (Log a) where
   Exp a * Exp b
     | isInfinite a && isInfinite b && a == -b = Exp negInf
@@ -198,17 +213,6 @@ instance (Precise a, RealFloat a) => Num (Log a) where
     | a >= b    = Exp (a + log1pexp (b - a))
     | otherwise = Exp (b + log1pexp (a - b))
   {-# INLINE (+) #-}
-  -- >>> 3 - 1 :: Log Double
-  -- 2.0000000000000004
-  --
-  -- >>> 1 - 3 :: Log Double
-  -- NaN
-  -- 
-  -- >>> 3 - 2 :: Log Float
-  -- 1.0
-  --
-  -- >>> 1 - 3 :: Log Float
-  -- NaN
   Exp a - Exp b
     | a == negInf && b == negInf = Exp negInf
     | otherwise = Exp (a + log1mexp (b - a))


### PR DESCRIPTION
There was an extra 'negate' in the definitions of 'log1mexp' which caused any "a - b" where a > b to return NaN instead of a reasonable value.
