### PR TITLE
[RFC] Log: Ensure negate doesn't loop

### DIFF
--- a/src/Numeric/Log.hs
+++ b/src/Numeric/Log.hs
@@ -207,7 +207,7 @@ instance (Precise a, RealFloat a) => Num (Log a) where
     | a > negInf  = 1
     | otherwise   = negInf
   {-# INLINE signum #-}
-  negate _ = negInf
+  negate _ = Exp $ log negInf -- not a number
   {-# INLINE negate #-}
   abs = id
   {-# INLINE abs #-}


### PR DESCRIPTION
Previously it was defined in terms of `negInf`, which itself is defined
in terms of `negate`. We now just define it as `NaN`.

Does this seem reasonable?