### PR TITLE
log-domain.cabal: allow binary-0.8 (comes with ghc-8) and comonad-5

### DIFF
--- a/log-domain.cabal
+++ b/log-domain.cabal
@@ -43,10 +43,10 @@ flag ffi
 library
   build-depends:
     base                      >= 4.3      && < 5,
-    binary                    >= 0.5      && < 0.8,
+    binary                    >= 0.5      && < 0.9,
     bytes                     >= 0.7      && < 1,
     cereal                    >= 0.3.5    && < 0.6,
-    comonad                   >= 4        && < 5,
+    comonad                   >= 4        && < 6,
     deepseq                   >= 1.3      && < 1.5,
     distributive              >= 0.3      && < 1,
     hashable                  >= 1.1.2.3  && < 1.3,


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich <siarheit@google.com>