### PR TITLE
Fix tests when building with stack

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -41,6 +41,10 @@ generateBuildModule verbosity pkg lbi = do
     withTestLBI pkg lbi $ \suite suitecfg -> do
       rewriteFile (dir </> "Build_" ++ testName suite ++ ".hs") $ unlines
         [ "module Build_" ++ testName suite ++ " where"
+        , ""
+        , "autogen_dir :: String"
+        , "autogen_dir = " ++ show dir
+        , ""
         , "deps :: [String]"
         , "deps = " ++ (show $ formatdeps (testDeps libcfg suitecfg))
         ]

--- a/tests/doctests.hsc
+++ b/tests/doctests.hsc
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------
 module Main where
 
-import Build_doctests (deps)
+import Build_doctests (autogen_dir, deps)
 import Control.Applicative
 import Control.Monad
 import Data.List
@@ -54,11 +54,10 @@ withUnicode m = m
 main :: IO ()
 main = withUnicode $ getSources >>= \sources -> doctest $
     "-isrc"
-  : "-idist/build/autogen"
+  : ("-i" ++ autogen_dir)
   : "-optP-include"
-  : "-optPdist/build/autogen/cabal_macros.h"
+  : ("-optP" ++ autogen_dir ++ "/cabal_macros.h")
   : "-hide-all-packages"
-  : "-Iincludes"
   : map ("-package="++) deps ++ sources
 
 getSources :: IO [FilePath]


### PR DESCRIPTION
Currently, the doctests fail since it can't find the directory that `stack` puts autogen'd files in.

This would allow `log-domain`'s tests to be put on Stackage.