### PR TITLE
Improve accuracy and domain of various functions

### DIFF
--- a/src/Numeric/Log.hs
+++ b/src/Numeric/Log.hs
@@ -458,6 +458,53 @@ sum xs = Exp $ case Foldable.foldl' step1 None xs of
     step2 a r (Exp x) = r + expm1 (x - a)
 {-# INLINE sum #-}
 
+-- $LogFloatingTests
+--
+-- >>> (sinh (Exp (-17)) :: Log Double) ~= Exp (-17)
+-- True
+--
+-- >>> (sinh (Exp (-18)) :: Log Double) ~= Exp (-18)
+-- True
+--
+-- >>> sinh 0 :: Log Double
+-- 0.0
+--
+-- >>> (sinh 1 :: Log Double) ~= 1.1752
+-- True
+--
+-- >>> floor (ln (sinh (Exp 12) :: Log Double))
+-- 162754
+--
+-- >>> cosh 0 :: Log Double
+-- 1.0
+--
+-- >>> (cosh 1 :: Log Double) ~= 1.543
+-- True
+--
+-- >>> floor (ln (cosh (Exp 12) :: Log Double))
+-- 162754
+--
+-- >>> (tanh (Exp (-17)) :: Log Double) ~= Exp (-17)
+-- True
+--
+-- >>> (tanh (Exp (-18)) :: Log Double) ~= Exp (-18)
+-- True
+--
+-- >>> tanh 0 :: Log Double
+-- 0.0
+--
+-- >>> (tanh 1 :: Log Double) ~= (sinh 1 / cosh 1)
+-- True
+--
+-- >>> tanh (Exp 12) :: Log Double
+-- 1.0
+--
+-- >>> (log1p 1 :: Log Double) ~= log 2
+-- True
+--
+-- >>> log (log1p (Exp (exp 100)) :: Log Double) ~= 100
+-- True
+
 instance RealFloat a => Floating (Log a) where
   pi = Exp (log pi)
   {-# INLINE pi #-}

--- a/src/Numeric/Log.hs
+++ b/src/Numeric/Log.hs
@@ -464,7 +464,7 @@ instance RealFloat a => Floating (Log a) where
   {-# INLINE (**) #-}
   sqrt (Exp a) = Exp (a / 2)
   {-# INLINE sqrt #-}
-  logBase (Exp a) (Exp b) = Exp (log (logBase (exp a) (exp b)))
+  logBase (Exp a) (Exp b) = Exp (log (b / a))
   {-# INLINE logBase #-}
   sin = logMap sin
   {-# INLINE sin #-}

--- a/src/Numeric/Log/Signed.hs
+++ b/src/Numeric/Log/Signed.hs
@@ -42,7 +42,7 @@ negInf = (-1)/0
 nan :: Fractional a => a
 nan = 0/0
 
--- Machine epsilon, the difference between 1 and the next representable value
+-- | Machine epsilon, the difference between 1 and the next representable value
 eps :: RealFloat a => a
 eps = let ret = scaleFloat (1 - floatDigits ret) 1 in ret
 

--- a/src/Numeric/Log/Signed.hs
+++ b/src/Numeric/Log/Signed.hs
@@ -44,7 +44,7 @@ nan = 0/0
 
 multSign :: (Num a) => Bool -> a -> a
 multSign True = id
-multSign False = (*) (-1)
+multSign False = negate
 
 -- $SignedLogCompTests
 --

--- a/src/Numeric/Log/Signed.hs
+++ b/src/Numeric/Log/Signed.hs
@@ -242,6 +242,65 @@ logMap f (SLExp sA a) = SLExp (value >= 0) $ log $ abs value
   where value = f $ multSign sA $ exp a
 {-# INLINE logMap #-}
 
+-- $SignedLogFloatingTests
+--
+-- >>> (sinh (SLExp True (-17)) :: SignedLog Double) ~= SLExp True (-17)
+-- True
+--
+-- >>> (sinh (SLExp True (-18)) :: SignedLog Double) ~= SLExp True (-18)
+-- True
+--
+-- >>> sinh 0 :: SignedLog Double
+-- 0.0
+--
+-- >>> (sinh 1 :: SignedLog Double) ~= 1.1752
+-- True
+--
+-- >>> (sinh (-1) :: SignedLog Double) == negate (sinh 1)
+-- True
+--
+-- >>> floor (lnSL (sinh (SLExp True 12) :: SignedLog Double))
+-- 162754
+--
+-- >>> cosh 0 :: SignedLog Double
+-- 1.0
+--
+-- >>> (cosh 1 :: SignedLog Double) ~= 1.543
+-- True
+--
+-- >>> (cosh (-1) :: SignedLog Double) == cosh 1
+-- True
+--
+-- >>> floor (lnSL (cosh (SLExp True 12) :: SignedLog Double))
+-- 162754
+--
+-- >>> (tanh (SLExp True (-17)) :: SignedLog Double) ~= SLExp True (-17)
+-- True
+--
+-- >>> (tanh (SLExp True (-18)) :: SignedLog Double) ~= SLExp True (-18)
+-- True
+--
+-- >>> tanh 0 :: SignedLog Double
+-- 0.0
+--
+-- >>> (tanh 1 :: SignedLog Double) ~= (sinh 1 / cosh 1)
+-- True
+--
+-- >>> (tanh (-1) :: SignedLog Double) == negate (tanh 1)
+-- True
+--
+-- >>> tanh (SLExp True 12) :: SignedLog Double
+-- 1.0
+--
+-- >>> (log1p 1 :: SignedLog Double) ~= log 2
+-- True
+--
+-- >>> (log1p (-0.5) :: SignedLog Double) ~= log 0.5
+-- True
+--
+-- >>> log (log1p (SLExp True (exp 100)) :: SignedLog Double) ~= 100
+-- True
+
 instance RealFloat a => Floating (SignedLog a) where
   pi = SLExp True (log pi)
   {-# INLINE pi #-}

--- a/src/Numeric/Log/Signed.hs
+++ b/src/Numeric/Log/Signed.hs
@@ -244,7 +244,7 @@ instance RealFloat a => Floating (SignedLog a) where
   sqrt (SLExp False _) = nan
   {-# INLINE sqrt #-}
   logBase slA@(SLExp _ a) slB@(SLExp _ b) | slA >= 0 && slB >= 0 = SLExp (value >= 0) (log $ abs value)
-    where value = logBase (exp a) (exp b)
+    where value = b / a
   logBase _ _ = nan
   {-# INLINE logBase #-}
   sin = logMap sin

--- a/src/Numeric/Log/Signed.hs
+++ b/src/Numeric/Log/Signed.hs
@@ -303,6 +303,10 @@ instance RealFloat a => Floating (SignedLog a) where
   atanh = logMap atanh
   {-# INLINE atanh #-}
 
+  log1p (SLExp True a) = SLExp True (log (log1pexp a))
+  log1p (SLExp False a) = SLExp (a > 0) (log (negate (log1mexp a))) -- return positive NaN on failure
+  {-# INLINE log1p #-}
+
 -- $SignedLogProperFractionTests
 --
 -- >>> (properFraction (-1.5) :: (Integer, SignedLog Double))

--- a/src/Numeric/Log/Signed.hs
+++ b/src/Numeric/Log/Signed.hs
@@ -190,7 +190,7 @@ instance RealFloat a => Num (SignedLog a) where
   SLExp sA a * SLExp sB b = SLExp (nxor sA sB) (a+b)
   {-# INLINE (*) #-}
   SLExp sA a + SLExp sB b
-    | a == b && isInfinite a && (a < 0 || nxor sA sB) = SLExp True a
+    | a == b && isInfinite a && (a < 0 || nxor sA sB) = SLExp (sA && sB) a
     | sA == sB && a >= b     = SLExp sA (a + log1pexp (b - a))
     | sA == sB && otherwise  = SLExp sA (b + log1pexp (a - b))
     | sA /= sB && a == b && not (isInfinite a) = SLExp True negInf


### PR DESCRIPTION
Changes:
- `logBase` is more efficient and defined over a larger domain.
- `(-Infinity) + (-Infinity)` is now `-Infinity`, not `Infinity`.
- `(-0) + (-0)` is now `-0`, not `0`. See also #34.
- `show (-0)` is now `-0.0`, not `0.0`. See also #34.
- `signum (-0)` is now `-0`, not `0`. See also #34.
- `sinh`, `cosh`, and `tanh` are defined over a larger domain and marginally more accurate in a few cases.
- `log1p` is defined over a larger domain.
- Tests for the above have been added.